### PR TITLE
Simplify email login

### DIFF
--- a/authl/__init__.py
+++ b/authl/__init__.py
@@ -100,12 +100,13 @@ def from_config(config, secret_key):
         INDIELOGIN_CLIENT_ID -- enable the IndieLogin handler
 
     """
+    # pylint:disable=unused-argument
 
     handlers = []
     if config.get('EMAIL_FROM') or config.get('EMAIL_SENDMAIL'):
         from .handlers import email_addr
 
-        handlers.append(email_addr.from_config(config, secret_key))
+        handlers.append(email_addr.from_config(config))
 
     if config.get('MASTODON_NAME'):
         from .handlers import mastodon

--- a/authl/flask.py
+++ b/authl/flask.py
@@ -184,7 +184,8 @@ def setup(app,
           session_auth_name='me',
           force_ssl=False,
           stylesheet=None,
-          on_verified=None
+          on_verified=None,
+          make_permanent=True
           ):
     """ Setup Authl to work with a Flask application.
 
@@ -212,6 +213,8 @@ def setup(app,
     stylesheet -- the URL to use for the default page stylesheet
     on_verified -- A function to call on successful login (called after
         setting the session value)
+    make_permanent -- Whether a session should persist past the browser window
+        closing
 
     The login_render_func takes the following arguments:
 
@@ -268,7 +271,7 @@ def setup(app,
         if isinstance(disp, disposition.Verified):
             # The user is verified; log them in
             LOGGER.info("Successful login: %s", disp.identity)
-            flask.session.permanent = True
+            flask.session.permanent = make_permanent
             flask.session[session_auth_name] = disp.identity
 
             if on_verified:
@@ -312,10 +315,9 @@ def setup(app,
             if result:
                 return result
 
-        # Default template that shows a login form and flashes all pending messages
         return flask.render_template_string(DEFAULT_LOGIN_TEMPLATE,
                                             login_url=login_url,
-                                            stylesheet_url=stylesheet,
+                                            stylesheet=stylesheet,
                                             auth=instance)
 
     def login(redir=''):

--- a/authl/handlers/email_addr.py
+++ b/authl/handlers/email_addr.py
@@ -7,6 +7,7 @@ import time
 import urllib.parse
 import html
 import uuid
+import base64
 
 import expiringdict
 import validate_email
@@ -120,7 +121,7 @@ class EmailAddress(Handler):
                 email=html.escape(dest_addr),
                 minutes=math.ceil(wait_time / 60)))
 
-        token = str(uuid.uuid4())
+        token = base64.urlsafe_b64encode(uuid.uuid4().bytes).decode().replace('=','')
         link_url = (callback_url + ('&' if '?' in callback_url else '?') +
             urllib.parse.urlencode({'t':token}))
 

--- a/authl/handlers/indielogin.py
+++ b/authl/handlers/indielogin.py
@@ -3,12 +3,11 @@
 import json
 import logging
 import urllib.parse
-import uuid
 
 import expiringdict
 import requests
 
-from .. import disposition
+from .. import disposition, utils
 from . import Handler
 
 LOGGER = logging.getLogger(__name__)
@@ -74,7 +73,7 @@ class IndieLogin(Handler):
         LOGGER.info('Initiate auth: %s %s', id_url, callback_url)
 
         # register a new transaction ID
-        state = str(uuid.uuid4())
+        state = utils.gen_token()
         self._pending[state] = {'id_url': id_url, 'callback_uri': callback_url}
 
         auth_url = (

--- a/authl/handlers/mastodon.py
+++ b/authl/handlers/mastodon.py
@@ -5,12 +5,11 @@ import json
 import logging
 import re
 import urllib.parse
-import uuid
 
 import expiringdict
 import requests
 
-from .. import disposition
+from .. import disposition, utils
 from . import Handler
 
 LOGGER = logging.getLogger(__name__)
@@ -111,7 +110,7 @@ class Mastodon(Handler):
     def initiate_auth(self, id_url, callback_url):
         instance = self._get_instance(id_url)
 
-        state = str(uuid.uuid4())
+        state = utils.gen_token()
 
         client = self._get_client(instance, callback_url)
         if not client:

--- a/authl/utils.py
+++ b/authl/utils.py
@@ -1,0 +1,9 @@
+""" Utility functions """
+
+import base64
+import uuid
+
+
+def gen_token():
+    """ Generate a random URL-safe token string """
+    return base64.urlsafe_b64encode(uuid.uuid4().bytes).decode().replace('=', '')

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ setup(
         'beautifulsoup4',
         'requests',
         'validate_email',
-        'ska',
         'expiringdict',
     ],
 


### PR DESCRIPTION
Since all the other backends are stateful and therefore not load-balancer-friendly, might as well make the email handler like that too. This makes the callback URLs way shorter and more opaque.