### PR TITLE
Add Twitter handler, and refactor how handlers handle redirection

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -55,6 +55,13 @@
             ],
             "version": "==2.8"
         },
+        "oauthlib": {
+            "hashes": [
+                "sha256:bee41cc35fcca6e988463cacc3bcb8a96224f470ca547e697b604cc697b2f889",
+                "sha256:df884cd6cbe20e32633f1db1072e9356f53638e4361bef4e8b03c9127c9328ea"
+            ],
+            "version": "==3.1.0"
+        },
         "requests": {
             "hashes": [
                 "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
@@ -62,12 +69,19 @@
             ],
             "version": "==2.22.0"
         },
+        "requests-oauthlib": {
+            "hashes": [
+                "sha256:bd6533330e8748e94bf0b214775fed487d309b8b8fe823dc45641ebcd9a32f57",
+                "sha256:d3ed0c8f2e3bbc6b344fa63d6f933745ab394469da38db16bdddb461c7e25140"
+            ],
+            "version": "==1.2.0"
+        },
         "soupsieve": {
             "hashes": [
-                "sha256:72b5f1aea9101cf720a36bb2327ede866fd6f1a07b1e87c92a1cc18113cbc946",
-                "sha256:e4e9c053d59795e440163733a7fec6c5972210e1790c507e4c7b051d6c5259de"
+                "sha256:8662843366b8d8779dec4e2f921bebec9afd856a5ff2e82cd419acc5054a1a92",
+                "sha256:a5a6166b4767725fd52ae55fee8c8b6137d9a51e9f1edea461a062a759160118"
             ],
-            "version": "==1.9.2"
+            "version": "==1.9.3"
         },
         "urllib3": {
             "hashes": [
@@ -339,10 +353,10 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:1dc82f87a8726602fa7177a091b5e8691d6523138a8f7acd08e58088f51e389f",
-                "sha256:47220a4f2aeebbc74b0ab317584264ea44c745e1fd5ff316b675cd0aff8afad8"
+                "sha256:438d6a735167099d75e5fd9a55175c6727c4dbba345ae406b2886c2728fe3e80",
+                "sha256:ebc205051d79b49989140f5f6c73ec23fce5f590cbc4d9cd6e4c47f168fa0f10"
             ],
-            "version": "==4.33.0"
+            "version": "==4.34.0"
         },
         "twine": {
             "hashes": [

--- a/authl/__init__.py
+++ b/authl/__init__.py
@@ -113,6 +113,10 @@ def from_config(config: typing.Dict[str, typing.Any], token_store=None) -> Authl
         from .handlers import indielogin
         instance.add_handler(indielogin.from_config(config, token_store))
 
+    if config.get('TWITTER_CLIENT_KEY'):
+        from .handlers import twitter
+        instance.add_handler(twitter.from_config(config, token_store))
+
     if config.get('TEST_ENABLED'):
         from .handlers import test_handler
         instance.add_handler(test_handler.TestHandler())

--- a/authl/disposition.py
+++ b/authl/disposition.py
@@ -20,11 +20,12 @@ class Verified(Disposition):
     client to the actual view
 
     Profile will just be a MultiDict with whatever other junk the provider
-    includes in the profile, which is probably useful for some use case
+    includes in the profile, which is probably useful for some use case.
     """
 
-    def __init__(self, identity, profile=None):
+    def __init__(self, identity, redir, profile=None):
         self.identity = identity
+        self.redir = redir
         self.profile = profile or {}
 
 

--- a/authl/handlers/__init__.py
+++ b/authl/handlers/__init__.py
@@ -46,11 +46,12 @@ class Handler(ABC):
         and should be short and stable. """
 
     @abstractmethod
-    def initiate_auth(self, id_url: str, callback_url: str) -> disposition.Disposition:
+    def initiate_auth(self, id_url: str, callback_uri: str, redir: str) -> disposition.Disposition:
         """ Initiates a remote auth request
 
         :param str id_url: Canonicized identity URL
-        :param str callback_url: Callback URL for verification
+        :param str callback_uri: Callback URL for verification
+        :param str redir: Where to redirect the user to after verification
 
         Returns a Disposition object to be handled by the frontend.
         """

--- a/authl/handlers/test_handler.py
+++ b/authl/handlers/test_handler.py
@@ -14,8 +14,8 @@ class TestHandler(Handler):
             return url
         return None
 
-    def initiate_auth(self, id_url, callback_url):
-        return disposition.Verified(id_url)
+    def initiate_auth(self, id_url, callback_uri, redir):
+        return disposition.Verified(id_url, redir)
 
     def check_callback(self, url, get, data):
         return disposition.Error("This shouldn't be possible")

--- a/authl/handlers/twitter.py
+++ b/authl/handlers/twitter.py
@@ -1,0 +1,135 @@
+""" Twitter login handler """
+
+import re
+import urllib.parse
+
+import requests
+from requests_oauthlib import OAuth1, OAuth1Session
+
+from .. import disposition
+from . import Handler
+
+
+class Twitter(Handler):
+    """ Twitter handler. Needs a client_key and client_secret. It is HIGHLY
+    RECOMMENDED that these configuration parameters be provided via an
+    environment variable rather than by checked-in code, as a basic security
+    precaution. """
+
+    @property
+    def description(self):
+        return """Allows users to log on via <a href="https://twitter.com/">Twitter</a>."""
+
+    @property
+    def service_name(self):
+        return "Twitter"
+
+    @property
+    def url_schemes(self):
+        return [('https://twitter.com/%', 'username')]
+
+    def __init__(self, token_store, client_key, client_secret):
+        self._client_key = client_key
+        self._client_secret = client_secret
+        self._pending = token_store
+
+    # regex to match a twitter URL and optionally extract the username
+    twitter_regex = re.compile(r'(https?://)?[^/]*\.?twitter\.com/?@?(.*)')
+
+    @staticmethod
+    def handles_url(url):
+        match = Twitter.twitter_regex.match(url)
+        if match:
+            return 'https://twitter.com/' + match.group(2)
+
+        return False
+
+    @property
+    def cb_id(self):
+        return 't'
+
+    def initiate_auth(self, id_url, callback_uri, redir):
+        match = Twitter.twitter_regex.match(id_url)
+        if not match:
+            return disposition.Error("Got invalid Twitter URL")
+
+        username = match.group(2)
+        oauth_session = OAuth1Session(
+            client_key=self._client_key,
+            client_secret=self._client_secret,
+            callback_uri=callback_uri)
+
+        req = oauth_session.fetch_request_token('https://api.twitter.com/oauth/request_token')
+
+        token = req.get('oauth_token')
+        params = {
+            'oauth_token': token,
+            'oauth_token_secret': req.get('oauth_token_secret')
+        }
+        if username:
+            params['screen_name'] = username
+
+        self._pending[token] = (params, callback_uri, redir)
+
+        return disposition.Redirect(
+            'https://api.twitter.com/oauth/authorize?' + urllib.parse.urlencode(params))
+
+    def check_callback(self, url, get, data):
+        token = get.get('oauth_token')
+        if not token:
+            return disposition.Error("No transaction ID provided")
+        if token not in self._pending:
+            return disposition.Error("Transaction invalid or expired")
+
+        if not get.get('oauth_verifier'):
+            return disposition.Error("Twitter authorization declined")
+
+        params, callback_uri, redir = self._pending[token]
+
+        oauth_session = OAuth1Session(
+            client_key=self._client_key,
+            client_secret=self._client_secret,
+            resource_owner_key=params['oauth_token'],
+            resource_owner_secret=params['oauth_token_secret'],
+            callback_uri=callback_uri)
+
+        oauth_session.parse_authorization_response(url)
+
+        request = oauth_session.fetch_access_token('https://api.twitter.com/oauth/access_token')
+        auth = OAuth1(
+            client_key=self._client_key,
+            client_secret=self._client_secret,
+            resource_owner_key=request.get('oauth_token'),
+            resource_owner_secret=request.get('oauth_token_secret'))
+
+        user_info = requests.get(
+            'https://api.twitter.com/1.1/account/verify_credentials.json', auth=auth).json()
+        if 'errors' in user_info:
+            return disposition.Error("Could not retrieve credentials: %r" % user_info.get('errors'))
+
+        user_id = user_info.get('id_str')
+        username = user_info.get('screen_name')
+        # We include the user ID after the hash code to prevent folks from
+        # logging in by taking over a username that someone changed/abandoned.
+        return disposition.Verified(
+            'https://twitter.com/{}#{}'.format(username, user_id),
+            redir,
+            user_info)
+
+
+def from_config(config, token_store):
+    """ Generate a Twitter handler from the given config dictionary.
+
+    Posible configuration values:
+
+    TWITTER_CLIENT_KEY -- The Twitter app's client_key
+    TWITTER_CLIENT_SECRET -- The Twitter app's client_secret
+
+    It is ***HIGHLY RECOMMENDED*** that these configuration values be provided
+    via environment variables or some other mechanism that doesn't involve
+    checking these values into source control and exposing them on the
+    file system.
+    """
+
+    return Twitter(token_store, config['TWITTER_CLIENT_KEY'],
+                   config['TWITTER_CLIENT_SECRET'])

--- a/authl/utils.py
+++ b/authl/utils.py
@@ -2,7 +2,6 @@
 
 import base64
 import html
-import json
 import logging
 import re
 import uuid
@@ -36,9 +35,9 @@ def get_webfinger_profile(user, domain):
         return None
 
     try:
-        profile = json.loads(request.text)
-    except json.JSONDecodeError as err:
-        LOGGER.info("Profile decode of %s failed: %s", resource, err)
+        profile = request.json()
+    except ValueError:
+        LOGGER.info("Profile decode of %s failed", resource)
         return None
 
     try:

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
         'beautifulsoup4',
         'expiringdict',
         'requests',
+        'requests_oauthlib',
         'validate_email',
     ],
 

--- a/test.py
+++ b/test.py
@@ -8,6 +8,7 @@ Run it locally with:
  """
 
 import logging
+import os
 import uuid
 
 import flask
@@ -42,7 +43,10 @@ authl.flask.setup(
         'TEST_ENABLED': True,
 
         'MASTODON_NAME': 'authl testing',
-        'MASTODON_HOMEPAGE': 'https://github.com/PlaidWeb/Authl'
+        'MASTODON_HOMEPAGE': 'https://github.com/PlaidWeb/Authl',
+
+        'TWITTER_CLIENT_KEY': os.environ.get('TWITTER_CLIENT_KEY'),
+        'TWITTER_CLIENT_SECRET': os.environ.get('TWITTER_CLIENT_SECRET'),
     },
     tester_path='/check_url',
     on_verified=on_login


### PR DESCRIPTION
The old callback-stores-the-redirection-target stuff was to support the bad
old days of signed URLs for email login, but we're not doing that anymore
since all the login handlers require maintaining state anyway. So now the
redirection target just gets managed by the handler as part of the transaction
state. This was necessary because Twitter requires an exact match on callback
URL, and there are probably other providers which will as well; the fact the
other providers could be loosy-goosy about the callback URL isn't really a
feature.

Also, this makes things more flexible for frameworks which aren't Flask, since
there are situations where simply putting the redirection target into the URL
might not be the appropriate choice.

This also aids privacy somewhat since now the identity server
won't know anything about what URL the user is trying to log into anyway.

Basically this makes things more sensible in the long run for everyone.

Fixes #9 