### PR TITLE
Preserve the id_url during error flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ The basic API works, and provides an easy drop-in set of endpoints for
 Currently supported authentication mechanisms:
 
 * Directly authenticating against email using a magic link
-* Federated authentication against [Mastodon](https://joinmastodon.org/)
+* Federated authentication against Fediverse providers
+    ([Mastodon](https://joinmastodon.org/), [Pleroma](https://pleroma.social))
 * Federated authentication against [IndieAuth](https://indieauth.net/)
 * Federated authentication against [IndieLogin](https://indielogin.com/)
 * Silo authentication against [Twitter](https://twitter.com/)

--- a/authl/__init__.py
+++ b/authl/__init__.py
@@ -7,7 +7,7 @@ import typing
 import itsdangerous
 from bs4 import BeautifulSoup
 
-from . import handlers, utils
+from . import handlers, utils, disposition
 
 LOGGER = logging.getLogger(__name__)
 
@@ -57,7 +57,7 @@ class Authl:
 
     def get_handler_by_id(self, handler_id):
         """ Get the handler with the given ID """
-        return self._handlers[handler_id]
+        return self._handlers.get(handler_id)
 
     @property
     def handlers(self):
@@ -95,9 +95,9 @@ def from_config(config: typing.Dict[str, typing.Any],
         from .handlers import email_addr
         instance.add_handler(email_addr.from_config(config, serializer))
 
-    if config.get('MASTODON_NAME'):
-        from .handlers import mastodon
-        instance.add_handler(mastodon.from_config(config, serializer))
+    if config.get('FEDIVERSE_NAME') or config.get('MASTODON_NAME'):
+        from .handlers import fediverse
+        instance.add_handler(fediverse.from_config(config, serializer))
 
     if config.get('INDIEAUTH_CLIENT_ID'):
         from .handlers import indieauth

--- a/authl/__init__.py
+++ b/authl/__init__.py
@@ -7,7 +7,7 @@ import typing
 import itsdangerous
 from bs4 import BeautifulSoup
 
-from . import handlers, utils, disposition
+from . import handlers, utils
 
 LOGGER = logging.getLogger(__name__)
 

--- a/authl/flask_templates/authl.css
+++ b/authl/flask_templates/authl.css
@@ -43,20 +43,11 @@ a:link {
 .description a:link {
     color: #944;
 }
-.flashes {
+.error {
     color: #700;
-    list-style-type: none;
     font-size: small;
     margin: 0;
     padding: 0;
-}
-.flashes li {
-    margin: 0;
-    padding: 0;
-    display: inline;
-}
-.flashes li + li::before {
-    content: ' | ';
 }
 
 #powered {

--- a/authl/flask_templates/login.html
+++ b/authl/flask_templates/login.html
@@ -103,15 +103,9 @@ window.addEventListener('DOMContentLoaded', () => {
         <form method="POST" action="{{login_url}}" novalidate>
             <input id="me" type="url" name="me" size="40" placeholder="Your ID here" value="{{request.args.fill}}" autofocus>
             <button id="uri-type">Go!</button>
-            {% with messages = get_flashed_messages() %}
-            {% if messages %}
-            <ul class="flashes">
-                {% for message in messages %}
-                <li>{{ message }}</li>
-                {% endfor %}
-            </ul>
+            {% if error %}
+            <div class="error">{{error}}</div>
             {% endif %}
-            {% endwith %}
         </form>
 
         <div id="info">

--- a/authl/flask_templates/login.html
+++ b/authl/flask_templates/login.html
@@ -101,7 +101,7 @@ window.addEventListener('DOMContentLoaded', () => {
     <div id="login">
         <h1>Identify Yourself</h1>
         <form method="POST" action="{{login_url}}" novalidate>
-            <input id="me" type="url" name="me" size="40" placeholder="Your ID here" value="{{request.args.fill}}" autofocus>
+            <input id="me" type="url" name="me" size="40" placeholder="Your ID here" value="{{request.args.get('fill',id_url)}}" autofocus>
             <button id="uri-type">Go!</button>
             {% if error %}
             <div class="error">{{error}}</div>

--- a/authl/handlers/email_addr.py
+++ b/authl/handlers/email_addr.py
@@ -41,8 +41,8 @@ class EmailAddress(Handler):
 
     @property
     def description(self):
-        return """Uses a good old-fashioned email address to log you in, by sending a
-        "magic link" to the destination address."""
+        return """Uses email to log you in, by sending a "magic link" to the
+        destination address."""
 
     @property
     def cb_id(self):

--- a/authl/handlers/fediverse.py
+++ b/authl/handlers/fediverse.py
@@ -240,6 +240,15 @@ def from_config(config, token_store):
     Fediverse_TIMEOUT -- the maximum time to wait for login to complete
     """
 
-    return Fediverse(config['Fediverse_NAME'], token_store,
-                    timeout=config.get('Fediverse_TIMEOUT'),
-                    homepage=config.get('Fediverse_HOMEPAGE'))
+    def get_cfg(key, dfl=None):
+        for pfx in ('FEDIVERSE_', 'MASTODON_'):
+            if pfx + key in config:
+                if pfx != 'FEDIVERSE_':
+                    LOGGER.warning("Configuration key %s has changed to %s",
+                                   pfx + key, 'FEDIVERSE_' + key)
+                return config[pfx + key]
+        return dfl
+
+    return Fediverse(get_cfg('NAME'), token_store,
+                     timeout=get_cfg('TIMEOUT'),
+                     homepage=get_cfg('HOMEPAGE'))

--- a/authl/handlers/fediverse.py
+++ b/authl/handlers/fediverse.py
@@ -1,4 +1,4 @@
-""" Mastodon/Pleroma/Fediverse provider """
+""" Fediverse/Pleroma/Fediverse provider """
 
 import functools
 import logging
@@ -13,11 +13,11 @@ from . import Handler
 LOGGER = logging.getLogger(__name__)
 
 
-class Mastodon(Handler):
-    """ Handler for Mastodon and Mastodon-like services """
+class Fediverse(Handler):
+    """ Handler for Fediverse services (Mastodon, Pleroma) """
 
     class Client:
-        """ Mastodon OAuth client info """
+        """ Fediverse OAuth client info """
         # pylint:disable=too-few-public-methods
 
         def __init__(self, instance, params, secrets):
@@ -34,7 +34,7 @@ class Mastodon(Handler):
 
     @property
     def service_name(self):
-        return "Mastodon"
+        return "Fediverse"
 
     @property
     def url_schemes(self):
@@ -43,16 +43,16 @@ class Mastodon(Handler):
 
     @property
     def description(self):
-        return """Identifies you using your choice of
-        <a href="https://joinmastodon.org/">Mastodon</a>
-        instance."""
+        return """Identifies you using your choice of Fediverse instance
+        (currently supported: <a href="https://joinmastodon.org/">Mastodon</a>,
+        <a href="https://pleroma.social/">Pleroma</a>)"""
 
     @property
     def cb_id(self):
         return 'md'
 
     def __init__(self, name: str, token_store: dict, timeout: int = None, homepage: str = None):
-        """ Instantiate a Mastodon handler.
+        """ Instantiate a Fediverse handler.
 
         :param str name: Human-readable website name
 
@@ -80,7 +80,7 @@ class Mastodon(Handler):
         instance = 'https://' + domain
 
         try:
-            LOGGER.debug("Trying Mastodon instance: %s", instance)
+            LOGGER.debug("Trying Fediverse instance: %s", instance)
             request = requests.get(instance + '/api/v1/instance')
             if request.status_code != 200:
                 LOGGER.debug("Instance endpoint returned error %d", request.status_code)
@@ -92,10 +92,10 @@ class Mastodon(Handler):
                     LOGGER.debug("Instance data missing key '%s'", key)
                     return None
 
-            LOGGER.info("Found Mastodon instance: %s", instance)
+            LOGGER.info("Found Fediverse instance: %s", instance)
             return instance
         except Exception as error:  # pylint:disable=broad-except
-            LOGGER.debug("Mastodon probe failed: %s", error)
+            LOGGER.debug("Fediverse probe failed: %s", error)
 
         return None
 
@@ -104,10 +104,10 @@ class Mastodon(Handler):
 
         instance = self._get_instance(url)
         if not instance:
-            LOGGER.debug("Not a Mastodon instance: %s", url)
+            LOGGER.debug("Not a Fediverse instance: %s", url)
             return None
 
-        # This seems to be a Mastodon endpoint; try to figure out the username
+        # This seems to be a Fediverse endpoint; try to figure out the username
         for tmpl in ('@(.*)@', '.*/@(.*)$', '.*/user/(.*)%'):
             match = re.match(tmpl, url)
             if match:
@@ -134,7 +134,7 @@ class Mastodon(Handler):
         if info['redirect_uri'] != callback_uri:
             raise ValueError("Got incorrect redirect_uri")
 
-        return Mastodon.Client(instance, {
+        return Fediverse.Client(instance, {
             'client_id': info['client_id'],
             'redirect_uri': info['redirect_uri'],
             'scope': 'read:accounts'
@@ -192,10 +192,10 @@ class Mastodon(Handler):
             client_tuple, redir = utils.unpack_token(self._token_store, state, self._timeout)
         except disposition.Disposition as disp:
             return disp
-        client = Mastodon.Client(*client_tuple)
+        client = Fediverse.Client(*client_tuple)
 
         if 'error' in get:
-            return disposition.Error("Error signing into Mastodon", redir)
+            return disposition.Error("Error signing into Fediverse", redir)
 
         try:
             request = requests.post(client.token_endpoint,
@@ -231,15 +231,15 @@ class Mastodon(Handler):
 
 
 def from_config(config, token_store):
-    """ Generate a Mastodon handler from the given config dictionary.
+    """ Generate a Fediverse handler from the given config dictionary.
 
     Posible configuration values:
 
-    MASTODON_NAME -- the name of your website (required)
-    MASTODON_HOMEPAGE -- your website's homepage (recommended)
-    MASTODON_TIMEOUT -- the maximum time to wait for login to complete
+    Fediverse_NAME -- the name of your website (required)
+    Fediverse_HOMEPAGE -- your website's homepage (recommended)
+    Fediverse_TIMEOUT -- the maximum time to wait for login to complete
     """
 
-    return Mastodon(config['MASTODON_NAME'], token_store,
-                    timeout=config.get('MASTODON_TIMEOUT'),
-                    homepage=config.get('MASTODON_HOMEPAGE'))
+    return Fediverse(config['Fediverse_NAME'], token_store,
+                    timeout=config.get('Fediverse_TIMEOUT'),
+                    homepage=config.get('Fediverse_HOMEPAGE'))

--- a/test.py
+++ b/test.py
@@ -43,8 +43,8 @@ authl.flask.setup(
 
         'TEST_ENABLED': True,
 
-        'MASTODON_NAME': 'authl testing',
-        'MASTODON_HOMEPAGE': 'https://github.com/PlaidWeb/Authl',
+        'FEDIVERSE_NAME': 'authl testing',
+        'FEDIVERSE_HOMEPAGE': 'https://github.com/PlaidWeb/Authl',
 
         'TWITTER_CLIENT_KEY': os.environ.get('TWITTER_CLIENT_KEY'),
         'TWITTER_CLIENT_SECRET': os.environ.get('TWITTER_CLIENT_SECRET'),


### PR DESCRIPTION
In AuthlFlask, this now stores the provisional id_url in the user session until a successful login occurs, so that the login form can be prefilled with the value.

Some miscellaneous changes for overall cleanups, as well as changing the name of Mastodon to Fediverse since it turns out that it also supports Pleroma.

Fixes #49 