### PR TITLE
Clarify OAuth identities

### DIFF
--- a/authl/flask_templates/login.html
+++ b/authl/flask_templates/login.html
@@ -113,18 +113,21 @@ window.addEventListener('DOMContentLoaded', () => {
             <p>This form allows you to log in using your existing identity from another website or
                 provider. The following sources are supported:</p>
             <ul class="handlers">
-                {% for handler in auth.handlers %}
-                {% for url,example in handler.url_schemes[:1] %}
-                <li><a class="$handler" href="?fill={{url.replace('%',example)|urlencode}}"
-                    data-url="{{url}}"
-                    data-example="{{example}}">{{handler.service_name}}</a>
-                    &mdash; <span class="description">{{handler.description|safe}}</span>
-                </li>
-                {% endfor %}
-                {% endfor %}
+                {%- for handler in auth.handlers -%}
+                    <li>
+                    {%- if handler.generic_url %}
+                        <a href="?me={{handler.generic_url}}">{{handler.service_name}}</a>
+                    {%- else -%}{%- for url,example in handler.url_schemes[:1] -%}
+                        <a class="$handler" href="?fill={{url.replace('%',example)|urlencode}}"
+                            data-url="{{url}}"
+                            data-example="{{example}}">{{handler.service_name}}</a>
+                    {%- endfor -%}{%- endif %}
+                        &mdash; <span class="description">{{handler.description|safe}}</span>
+                    </li>
+                {%- endfor -%}
             </ul>
 
-            <p>You may also provide your identity in <a class="$handler" href="?fill=@user@domain"
+            <p>You may also provide your address in <a class="$handler" href="?fill=@user@domain"
                 data-url="@%" data-example="user@domain">WebFinger format</a>.</p>
         </div>
 

--- a/authl/handlers/__init__.py
+++ b/authl/handlers/__init__.py
@@ -84,6 +84,11 @@ class Handler(ABC):
         """
 
     @property
+    def generic_url(self) -> typing.Optional[str]:
+        """ A generic URL that can be used for login irrespective of identity """
+        return None
+
+    @property
     @abstractmethod
     def description(self) -> str:
         """ Returns a description of the service, in HTML format. """

--- a/authl/handlers/fediverse.py
+++ b/authl/handlers/fediverse.py
@@ -39,8 +39,7 @@ class Fediverse(Handler):
 
     @property
     def url_schemes(self):
-        return [('https://%', 'instance/@username'),
-                ('@%', 'username@instance')]
+        return [('https://%', 'instance/')]
 
     @property
     def description(self):
@@ -72,14 +71,10 @@ class Fediverse(Handler):
     @staticmethod
     @functools.lru_cache(128)
     def _get_instance(url) -> typing.Optional[str]:
-        match = re.match('@.*@(.*)$', url)
-        if match:
-            domain = match[1]
-        else:
-            parsed = urllib.parse.urlparse(url)
-            if not parsed.netloc:
-                parsed = urllib.parse.urlparse('https://' + url)
-            domain = parsed.netloc
+        parsed = urllib.parse.urlparse(url)
+        if not parsed.netloc:
+            parsed = urllib.parse.urlparse('https://' + url)
+        domain = parsed.netloc
 
         instance = 'https://' + domain
 

--- a/authl/handlers/twitter.py
+++ b/authl/handlers/twitter.py
@@ -131,6 +131,7 @@ class Twitter(Handler):
     def generic_url(self):
         return 'https://twitter.com/'
 
+
 def from_config(config, storage):
     """ Generate a Twitter handler from the given config dictionary.
 

--- a/authl/handlers/twitter.py
+++ b/authl/handlers/twitter.py
@@ -127,6 +127,9 @@ class Twitter(Handler):
             redir,
             user_info)
 
+    @property
+    def generic_url(self):
+        return 'https://twitter.com/'
 
 def from_config(config, storage):
     """ Generate a Twitter handler from the given config dictionary.

--- a/authl/utils.py
+++ b/authl/utils.py
@@ -22,12 +22,13 @@ def read_file(filename):
 
 def get_webfinger_profiles(url: str) -> typing.Set[str]:
     """ Get the potential profile page URLs from a webfinger query """
-    webfinger = re.match(r'@([^@])+@(.*)$', url)
+    webfinger = re.match(r'@([^@]+)@(.*)$', url)
     if not webfinger:
         return set()
 
     try:
         user, domain = webfinger.group(1, 2)
+        LOGGER.debug("webfinger: user=%s domain=%s", user, domain)
 
         resource = 'https://{}/.well-known/webfinger?resource={}'.format(
             domain,


### PR DESCRIPTION
Fixes #24 and also removes redundant/never-called WebFinger support from Fediverse provider