### PR TITLE
Migrate to abstract TokenStore interface

### DIFF
--- a/authl/handlers/indieauth.py
+++ b/authl/handlers/indieauth.py
@@ -5,6 +5,7 @@ import time
 import typing
 import urllib.parse
 
+import expiringdict
 import requests
 from bs4 import BeautifulSoup
 
@@ -15,7 +16,7 @@ LOGGER = logging.getLogger(__name__)
 
 # We do this instead of functools.lru_cache so that IndieAuth.handles_page
 # and find_endpoint can both benefit from the same endpoint cache
-_ENDPOINT_CACHE = utils.LRUDict(maxsize=128)
+_ENDPOINT_CACHE = expiringdict.ExpiringDict(max_len=128, max_age_seconds=1800)
 
 
 def find_endpoint(id_url: str,

--- a/authl/tokens.py
+++ b/authl/tokens.py
@@ -1,0 +1,131 @@
+"""
+Token storage interface and some basic implementations thereof.
+
+The provided implementations are intended merely as a starting point that works
+for the most common cases with minimal external dependencies. In general, if
+you're only running a service on a single endpoint, use DictStore, and if you
+want to be able to load-balance, use Serializer. However, it is quite reasonable
+to have an implementation which is backed by a shared data store such as Redis
+or a SQL database.
+
+"""
+
+import typing
+from abc import ABC, abstractmethod
+
+import expiringdict
+import itsdangerous
+
+from . import disposition
+
+
+class TokenStore(ABC):
+    """
+
+    Storage for tokens; given some data to store, returns an opaque
+    identifier that can be used to reconstitute said token.
+
+    """
+    @abstractmethod
+    def put(self, value: typing.Any) -> str:
+        """ Generates a token with the specified stored values. """
+
+    @abstractmethod
+    def get(self, key: str, to_type=tuple) -> typing.Any:
+        """
+        Retrieves the token's value; can also raise disposition.Error if
+        this fails.
+        """
+
+    @abstractmethod
+    def remove(self, key: str):
+        """ Removes the key from the backing store, if appropriate. Is a no-op
+        if the key doesn't exist (or if there's no backing store). """
+
+    def pop(self, key: str, to_type=tuple) -> typing.Any:
+        """ Retrieves the token's values, and deletes the token from the backing
+        store. Even if the value retrieval fails, it will be removed. """
+        try:
+            stored = self.get(key, to_type)
+            return stored
+        finally:
+            self.remove(key)
+
+
+class DictStore(TokenStore):
+    """
+    A token store that stores the token values in a dict-like container.
+
+    This is suitable for the general case of having a single persistent service
+    running on a single endpoint.
+
+    The default storage is an expiringdict with a size limit of 1024
+    and a maximum lifetime of 1 hour. This can be tuned to your needs. In
+    particular, the lifetime never needs to be any higher than your longest
+    allowed transaction lifetime, and the size limit generally needs to be no
+    more than the number of concurrent logins at any given time.
+    """
+
+    def __init__(self, store: dict = None):
+        """ Initialize the store """
+        self._store: dict = expiringdict.ExpiringDict(
+            max_len=1024,
+            max_age_seconds=3600) if store is None else store
+
+    def put(self, value):
+        import uuid
+        key = str(uuid.uuid4())
+        self._store[key] = value
+        return key
+
+    def get(self, key, to_type=tuple):
+        try:
+            return to_type(self._store[key])
+
+        except KeyError:
+            raise disposition.Error("Invalid token", None)
+
+    def remove(self, key):
+        try:
+            del self._store[key]
+        except KeyError:
+            pass
+
+    def pop(self, key, to_type=tuple):
+        try:
+            return to_type(self._store.pop(key))
+        except KeyError:
+            raise disposition.Error("Invalid token", None)
+
+
+class Serializer(TokenStore):
+    """
+    A token store that stores the token values within the token name, using
+    a tamper-resistant signed serializer. Use this to avoid having a backing
+    store entirely, although the tokens can get quite large.
+
+    This is suitable for situations where you are load-balancing across multiple
+    nodes, or need tokens to persist across frequent service restarts, and don't
+    want to be dependent on a database. Note that all running instances will
+    need to share the same secret_key.
+    """
+
+    def __init__(self, secret_key):
+        """ Initializes the token store
+
+        :param str secret_key: The signing key for the serializer
+        """
+
+        self._serializer = itsdangerous.URLSafeSerializer(secret_key)
+
+    def put(self, value):
+        return self._serializer.dumps(value)
+
+    def get(self, key, to_type=tuple):
+        try:
+            return to_type(self._serializer.loads(key))
+        except itsdangerous.BadData:
+            raise disposition.Error("Invalid token", None)
+
+    def remove(self, key):
+        pass

--- a/authl/utils.py
+++ b/authl/utils.py
@@ -4,10 +4,7 @@ import collections
 import logging
 import os.path
 
-import itsdangerous
 import requests
-
-from . import disposition
 
 LOGGER = logging.getLogger(__name__)
 
@@ -53,25 +50,6 @@ def resolve_value(val):
     if callable(val):
         return val()
     return val
-
-
-def unpack_token(token_store, token: str, timeout: int) -> tuple:
-    """ Given a token_store, a token, and a timeout, try to unpack the data.
-    The token ***must*** be packed in the form of (client_data,redir).
-
-    On error, raises a disposition.Error which should be returned directly.
-    It is up to the handler to catch and return this!
-    """
-    try:
-        try:
-            cdata, redir = token_store.loads(token, max_age=timeout)
-        except itsdangerous.SignatureExpired:
-            _, redir = token_store.loads(token)
-            raise disposition.Error("Login has expired", redir)
-    except itsdangerous.BadData:
-        raise disposition.Error("Invalid token", None)
-
-    return cdata, redir
 
 
 class LRUDict(collections.OrderedDict):

--- a/authl/utils.py
+++ b/authl/utils.py
@@ -1,6 +1,5 @@
 """ Utility functions """
 
-import collections
 import logging
 import os.path
 
@@ -50,28 +49,3 @@ def resolve_value(val):
     if callable(val):
         return val()
     return val
-
-
-class LRUDict(collections.OrderedDict):
-    """ a Dict that has a size limit
-
-    borrowed from
-    https://docs.python.org/3/library/collections.html#ordereddict-examples-and-recipes
-
-    This exists because there is no way to inject known results into functools.lru_cache
-    and some of our flows benefit from being able to do that.
-    """
-
-    def __init__(self, *args, maxsize=128, **kwargs):
-        self.maxsize = maxsize
-        super().__init__(*args, **kwargs)
-
-    def __getitem__(self, key):
-        value = super().__getitem__(key)
-        self.move_to_end(key)
-        return value
-
-    def __setitem__(self, key, value):
-        super().__setitem__(key, value)
-        if len(self) > self.maxsize:
-            self.popitem(False)

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
 
     install_requires=[
         'beautifulsoup4',
+        'expiringdict',
         'itsdangerous',
         'read_only_property',
         'requests',

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -1,0 +1,81 @@
+""" Tests of the TokenStore implementations """
+# pylint:disable=missing-docstring
+
+
+import pytest
+
+from authl import disposition, tokens
+
+
+def test_dictstore():
+    store = tokens.DictStore({})
+
+    # different values should have different keys
+    token = store.put((1, 2, 3))
+    token2 = store.put((1, 2, 3))
+    assert token != token2
+    assert isinstance(token, str)
+    assert isinstance(token2, str)
+
+    # getting repeatedly should succeed
+    assert store.get(token) == (1, 2, 3)
+    assert store.get(token) == (1, 2, 3)
+    assert store.get(token) == (1, 2, 3)
+
+    # popping should remove it
+    assert store.pop(token) == (1, 2, 3)
+    with pytest.raises(disposition.Error):
+        store.get(token)
+    with pytest.raises(disposition.Error):
+        store.pop(token)
+
+    # removal should also remove it
+    store.remove(token2)
+    with pytest.raises(disposition.Error):
+        store.get(token2)
+    with pytest.raises(disposition.Error):
+        store.pop(token2)
+
+    # getting nonexistent should fail
+    with pytest.raises(disposition.Error):
+        store.get('bogus')
+
+    # removal should always work even if the token doesn't exist
+    store.remove(token)
+    store.remove(token2)
+    store.remove('bogus')
+
+
+def test_serializer():
+    store = tokens.Serializer(__name__)
+
+    # different values should get the same key
+    token = store.put((1, 2, 3))
+    token2 = store.put((1, 2, 3))
+    assert token == token2
+    assert isinstance(token, str)
+    assert isinstance(token2, str)
+
+    # getting repeatedly should succeed
+    assert store.get(token) == (1, 2, 3)
+    assert store.get(token) == (1, 2, 3)
+    assert store.get(token) == (1, 2, 3)
+
+    # popping won't remove it
+    assert store.pop(token) == (1, 2, 3)
+    assert store.get(token) == (1, 2, 3)
+
+    # removal also won't remove it
+    store.remove(token2)
+    store.remove(token2)
+    store.remove(token2)
+    assert store.get(token2) == (1, 2, 3)
+
+    # getting nonexistent should fail
+    with pytest.raises(disposition.Error):
+        store.get('bogus')
+
+    # removal should always work even if the token doesn't exist
+    store.remove(token)
+    store.remove(token2)
+    store.remove('bogus')


### PR DESCRIPTION
Fixes #67 

Also changes the default implementations:

* Authl's default is a UUID-based dict
* The Flask wrapper's default remains with a signed serializer
