### PR TITLE
Request a code in the 'me' scope

### DIFF
--- a/authl/handlers/indieauth.py
+++ b/authl/handlers/indieauth.py
@@ -291,7 +291,8 @@ class IndieAuth(Handler):
             'redirect_uri': callback_uri,
             'client_id': client_id,
             'state': state,
-            'response_type': 'id',
+            'response_type': 'code',
+            'scope': 'me',
             'me': id_url})
         return disposition.Redirect(url)
 

--- a/tests/handlers/test_indieauth.py
+++ b/tests/handlers/test_indieauth.py
@@ -165,7 +165,7 @@ def test_handler_success():
         assert 'client_id' in user_get
         assert 'state' in user_get
         assert user_get['state'] in store
-        assert user_get['response_type'] == 'id'
+        assert user_get['response_type'] == 'code'
         assert 'me' in user_get
 
         # fake the verification response


### PR DESCRIPTION
Because of https://github.com/indieweb/indieauth/issues/42, the `response_type=id` request is going away in favor of a scope-less `response_type=code`, but many endpoints (notably SelfAuth) do not support that, nor is this likely to be backwards-compatible with other existing endpoints. Fortunately, IndieAuth doesn't actually specify what scopes are valid, so for now Authl requests `scope=me`.

This has been tested against SelfAuth.

Fixes #82 