### PR TITLE
Replace differing URL verification with simpler, more robust logic

### DIFF
--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -4,6 +4,11 @@
 from . import TestHandler
 
 
+def test_version():
+    from authl import __version__
+    assert __version__.__version__
+
+
 def test_base_handler():
     handler = TestHandler()
     assert handler.handles_url('foo') is None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,6 +21,9 @@ def test_request_url():
         assert utils.request_url('http://nonexistent') is None
         assert utils.request_url('invalid://protocol') is None
 
+        mock.get('https://has.links/', headers={'Link': '<https://foo>; rel="bar"'})
+        assert utils.request_url('has.links').links['bar']['url'] == 'https://foo'
+
 
 def test_resolve_value():
     def moo():


### PR DESCRIPTION
Per https://github.com/indieweb/indieauth/issues/35 pretty much everyone agrees that it's better to just check to see if a differing profile URL has the same endpoint, rather than the complicated (and possibly fragile) "path extension" logic.