### PR TITLE
Add IndieAuth-related endpoints to the profile

### DIFF
--- a/authl/handlers/indieauth.py
+++ b/authl/handlers/indieauth.py
@@ -108,6 +108,8 @@ def find_endpoints(id_url: str,
         'token_endpoint',
         'ticket_endpoint',
         'webmention',
+        'micropub',
+        'microsub',
     ):
         endpoint = _derive_endpoint(links, content, rel)
         if endpoint:


### PR DESCRIPTION
This adds a new method, `indieauth.find_endpoints`, which gets several of the useful IndieWeb-related endpoints and adds them to the profile. Currently it will fetch:

* `authorization_endpoint`: IndieAuth
* `token_endpoint`: IndieAuth token grant
* `ticket_endpoint`: IndieAuth ticket grant, for [Ticket Auth](https://indieweb.org/IndieAuth_Ticket_Auth)
* `webmention`: [Webmention](https://indieweb.org/Webmention)
* `micropub`: [Micropub](https://indieweb.org/Micropub)
* `microsub`: [Microsub](https://indieweb.org/Microsub)

Additional endpoints can be added as necessary, but these seem like the most useful ones for all Authl-related use cases (e.g. implementing login flow and social readers).

I was tempted to automatically elide the terminal `_endpoint` for convenience, but it seems better to give the full name for the sake of clarity and consistency.
