### PR TITLE
Wrap email link callbacks in a POST form

### DIFF
--- a/authl/disposition.py
+++ b/authl/disposition.py
@@ -30,7 +30,7 @@ class Redirect(Disposition):
         self.url = url
 
     def __str__(self):
-        return 'REDIR:' + self.url
+        return f'REDIR:{self.url}'
 
 
 class Verified(Disposition):
@@ -63,7 +63,7 @@ class Verified(Disposition):
         self.profile = profile or {}
 
     def __str__(self):
-        return 'VERIFIED:' + self.identity
+        return f'VERIFIED:{self.identity}'
 
 
 class Notify(Disposition):
@@ -81,7 +81,7 @@ class Notify(Disposition):
         self.cdata = cdata
 
     def __str__(self):
-        return 'NOTIFY:' + str(self.cdata)
+        return f'NOTIFY:{str(self.cdata)}'
 
 
 class Error(Disposition):
@@ -98,4 +98,22 @@ class Error(Disposition):
         self.redir = redir
 
     def __str__(self):
-        return 'ERROR:' + self.message
+        return f'ERROR:{self.message}'
+
+
+class NeedsPost(Disposition):
+    """
+    Indicates that the callback needs to be re-triggered as a POST request.
+
+    :param str url: The URL that needs to be POSTed to
+    :param str message: A user-friendly message to display
+    :param dict data: POST data to be sent in the request, as key-value pairs
+    """
+
+    def __init__(self, url: str, message, data: dict):
+        self.url = url
+        self.message = str(message)
+        self.data = data
+
+    def __str__(self):
+        return f'NEEDS-POST:{self.message}'

--- a/authl/flask_templates/post-needed.html
+++ b/authl/flask_templates/post-needed.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<title>Complete your login</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<link rel="stylesheet" href="{{stylesheet}}">
+
+<script>
+window.addEventListener("load", () => {
+    document.forms['proxy'].submit();
+});
+</script>
+
+<body>
+    <div id="login">
+        <h1>Next Step</h1>
+
+        <div id="notify">
+            {{message}}
+
+            <form id="proxy" method="POST" action="{{url}}">
+                {% for name,value in data.items() %}
+                <input type="hidden" name="{{name}}" value="{{value}}">
+                {% endfor %}
+                <input type="submit" value="Log In">
+            </form>
+        </div>
+
+        <div id="powered">
+            <p>Powered by <a href="https://github.com/PlaidWeb/Authl">Authl</a></p>
+        </div>
+    </div>
+</body>
+</html>

--- a/authl/webfinger.py
+++ b/authl/webfinger.py
@@ -52,5 +52,5 @@ def get_profiles(url: str, timeout: int = 30) -> typing.Set[str]:
         return {link['href'] for link in profile['links']
                 if link['rel'] in ('http://webfinger.net/rel/profile-page', 'profile', 'self')}
     except Exception:  # pylint:disable=broad-except
-        LOGGER.exception("Failed to decode %s profile", resource)
+        LOGGER.info("Failed to decode %s profile", resource)
         return set()

--- a/test_app.py
+++ b/test_app.py
@@ -31,7 +31,7 @@ def on_login(verified):
 authl.flask.setup(
     app,
     {
-        'EMAIL_SENDMAIL': print,
+        'EMAIL_SENDMAIL': lambda message: print(message.get_payload(decode=True).decode('utf-8')),
         'EMAIL_FROM': 'nobody@example.com',
         'EMAIL_SUBJECT': 'Log in to authl test',
         'EMAIL_CHECK_MESSAGE': 'Use the link printed to the test console',

--- a/tests/test_disposition.py
+++ b/tests/test_disposition.py
@@ -9,3 +9,4 @@ def test_dispositions():
     assert 'foo' in str(disposition.Verified('foo', None))
     assert 'foo' in str(disposition.Notify('foo'))
     assert 'foo' in str(disposition.Error('foo', None))
+    assert 'foo' in str(disposition.NeedsPost('', 'foo', {}))


### PR DESCRIPTION
This prevents email link previewers (e.g. Outlook, Hotmail, etc.) from prefetching the actual login URL and messing up login state.

This does this by adding a new `disposition` type for `NeedsPost`, and implementing the appropriate machinery in the Flask wrapper as well. This change requires API updates in any application that isn't using the Flask wrapper but otherwise should be fairly transparent.

Fixes #109