### PR TITLE
Add libravatar support to the email handler

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ as appropriate.
 Installation
 ------------
 
-Authl requires Python 3.8.1 or later.
+Authl requires Python 3.9.2 or later.
 
 Install with pip::
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -646,6 +646,27 @@ files = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.7.0"
+description = "DNS toolkit"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "dnspython-2.7.0-py3-none-any.whl", hash = "sha256:b4c34b7d10b51bcc3a5071e7b8dee77939f1e878477eeecc965e9835f63c6c86"},
+    {file = "dnspython-2.7.0.tar.gz", hash = "sha256:ce9c432eda0dc91cf618a5cedf1a4e142651196bbcd2c80e89ed5a907e5cfaf1"},
+]
+
+[package.extras]
+dev = ["black (>=23.1.0)", "coverage (>=7.0)", "flake8 (>=7)", "hypercorn (>=0.16.0)", "mypy (>=1.8)", "pylint (>=3)", "pytest (>=7.4)", "pytest-cov (>=4.1.0)", "quart-trio (>=0.11.0)", "sphinx (>=7.2.0)", "sphinx-rtd-theme (>=2.0.0)", "twine (>=4.0.0)", "wheel (>=0.42.0)"]
+dnssec = ["cryptography (>=43)"]
+doh = ["h2 (>=4.1.0)", "httpcore (>=1.0.0)", "httpx (>=0.26.0)"]
+doq = ["aioquic (>=1.0.0)"]
+idna = ["idna (>=3.7)"]
+trio = ["trio (>=0.23)"]
+wmi = ["wmi (>=1.5.1)"]
+
+[[package]]
 name = "docutils"
 version = "0.20.1"
 description = "Docutils -- Python Documentation Utilities"
@@ -2838,4 +2859,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9.2,<4.0"
-content-hash = "5117a2da5f8401e3ae0462b9b39b0ee51e8a230fdffd653041852565a38d31e0"
+content-hash = "8b0db72704993d5ec90e99bf1f6db64fb3d8a89941928b0a7c8ebaaef77b6713"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ requests_oauthlib = "^2.0.0"
 validate_email = "^1.3"
 mf2py = "^2.0.1"
 mastodon-py = "^2.0.0"
+dnspython = "^2.7.0"
 
 [tool.poetry.group.dev.dependencies]
 autopep8 = "^2.3.2"

--- a/test_app.py
+++ b/test_app.py
@@ -35,6 +35,8 @@ authl.flask.setup(
         'EMAIL_SUBJECT': 'Log in to authl test',
         'EMAIL_CHECK_MESSAGE': 'Use the link printed to the test console',
         'EMAIL_EXPIRE_TIME': 60,
+        'EMAIL_AVATAR_SIZE': 256,
+        'EMAIL_AVATAR_DEFAULT': 'identicon',
 
         'INDIEAUTH_CLIENT_ID': authl.flask.client_id,
         'INDIEAUTH_PENDING_TTL': 10,
@@ -83,6 +85,10 @@ Want to <a href="{{url_for('logout', redir=request.path[1:])}}">log out</a>?</p>
 <li>{{k}}: {{v}}</li>
 {% endfor %}
 </ul>
+
+{% if profile.avatar %}
+<figure><img src="{{profile.avatar}}"></figure>
+{% endif %}
 {% endif %}""",
             me=flask.session['me'],
             profile=flask.session.get('profile')

--- a/tests/handlers/test_fediverse.py
+++ b/tests/handlers/test_fediverse.py
@@ -56,7 +56,7 @@ def test_handles_url(requests_mock):
 def mock_auth_request_url(**args):
     def mock_url(redirect_uris, scopes, state):
         # pylint:disable=unused-argument
-        return f"https://cb/?{urllib.parse.urlencode({'state':state, **args})}"
+        return f"https://cb/?{urllib.parse.urlencode({'state': state, **args})}"
     return mock_url
 
 


### PR DESCRIPTION
This adds support to [libravatar](https://libravatar.org/) profile images for the email handler.

The libravatar functionality really ought to be split out into its own library; unfortunately the existing libraries for this are extremely outdated and do not currently work.